### PR TITLE
feat: add per-IP rate limiting with TTL cleanup

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
 
       - name: Run go vet
         run: go vet ./...
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
 
       - name: Build
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bin/*
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+vendor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.23-alpine AS builder
+FROM golang:1.24-alpine AS builder
 
 RUN apk add --no-cache git make
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/beckxie/whatismyip
 
-go 1.23
+go 1.24.0
+
+toolchain go1.24.11
+
+require golang.org/x/time v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/time v0.14.0 h1:MRx4UaLrDotUKUdCIqzPC48t1Y9hANFKIRpNx+Te8PI=
+golang.org/x/time v0.14.0/go.mod h1:eL/Oa2bBBK0TkX57Fyni+NgnyQQN4LitPmob2Hjnqw4=

--- a/internal/middleware/ratelimit.go
+++ b/internal/middleware/ratelimit.go
@@ -1,0 +1,97 @@
+// Package middleware provides HTTP middleware components.
+package middleware
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"golang.org/x/time/rate"
+
+	"github.com/beckxie/whatismyip/internal/ip"
+)
+
+// ipLimiter wraps a rate.Limiter with last access time for TTL cleanup.
+type ipLimiter struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+// RateLimiter is a per-IP rate limiting middleware with automatic cleanup.
+type RateLimiter struct {
+	limiters sync.Map
+	rate     rate.Limit
+	burst    int
+	ttl      time.Duration
+}
+
+// NewRateLimiter creates a new RateLimiter.
+// r is the rate of requests per second, b is the burst size.
+// Starts a background goroutine to clean up expired entries.
+func NewRateLimiter(r float64, b int) *RateLimiter {
+	rl := &RateLimiter{
+		rate:  rate.Limit(r),
+		burst: b,
+		ttl:   30 * time.Minute, // Default TTL: 30 minutes
+	}
+
+	// Start background cleanup goroutine
+	go rl.cleanupLoop(10 * time.Minute)
+
+	return rl
+}
+
+// getLimiter returns the rate limiter for the given IP.
+func (rl *RateLimiter) getLimiter(clientIP string) *rate.Limiter {
+	now := time.Now()
+
+	if v, exists := rl.limiters.Load(clientIP); exists {
+		il := v.(*ipLimiter)
+		il.lastSeen = now
+		return il.limiter
+	}
+
+	il := &ipLimiter{
+		limiter:  rate.NewLimiter(rl.rate, rl.burst),
+		lastSeen: now,
+	}
+	rl.limiters.Store(clientIP, il)
+	return il.limiter
+}
+
+// cleanupLoop periodically removes expired entries.
+func (rl *RateLimiter) cleanupLoop(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for range ticker.C {
+		rl.cleanup()
+	}
+}
+
+// cleanup removes entries that haven't been accessed within TTL.
+func (rl *RateLimiter) cleanup() {
+	now := time.Now()
+	rl.limiters.Range(func(key, value any) bool {
+		il := value.(*ipLimiter)
+		if now.Sub(il.lastSeen) > rl.ttl {
+			rl.limiters.Delete(key)
+		}
+		return true
+	})
+}
+
+// Limit is the middleware handler.
+func (rl *RateLimiter) Limit(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		clientIP := ip.GetIP(r)
+		limiter := rl.getLimiter(clientIP)
+
+		if !limiter.Allow() {
+			http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/internal/middleware/ratelimit_test.go
+++ b/internal/middleware/ratelimit_test.go
@@ -1,0 +1,90 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRateLimiter_Allow(t *testing.T) {
+	rl := NewRateLimiter(1, 1) // 1 request per second, burst of 1
+
+	handler := rl.Limit(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// First request should pass
+	req := httptest.NewRequest(http.MethodGet, "/api/ip", nil)
+	req.RemoteAddr = "192.168.1.1:12345"
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	// Second immediate request should be rate limited
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("expected status %d, got %d", http.StatusTooManyRequests, w.Code)
+	}
+}
+
+func TestRateLimiter_DifferentIPs(t *testing.T) {
+	rl := NewRateLimiter(1, 1)
+
+	handler := rl.Limit(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	// Request from IP 1
+	req1 := httptest.NewRequest(http.MethodGet, "/api/ip", nil)
+	req1.RemoteAddr = "192.168.1.1:12345"
+	w1 := httptest.NewRecorder()
+	handler.ServeHTTP(w1, req1)
+
+	if w1.Code != http.StatusOK {
+		t.Errorf("IP1 first request: expected status %d, got %d", http.StatusOK, w1.Code)
+	}
+
+	// Request from IP 2 should also pass (different IP)
+	req2 := httptest.NewRequest(http.MethodGet, "/api/ip", nil)
+	req2.RemoteAddr = "192.168.1.2:12345"
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req2)
+
+	if w2.Code != http.StatusOK {
+		t.Errorf("IP2 first request: expected status %d, got %d", http.StatusOK, w2.Code)
+	}
+}
+
+func TestRateLimiter_Recovery(t *testing.T) {
+	rl := NewRateLimiter(10, 1) // 10 requests per second for faster test
+
+	handler := rl.Limit(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/api/ip", nil)
+	req.RemoteAddr = "192.168.1.1:12345"
+
+	// First request
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("first request: expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	// Wait for token to replenish
+	time.Sleep(150 * time.Millisecond)
+
+	// Should be allowed again
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("after recovery: expected status %d, got %d", http.StatusOK, w.Code)
+	}
+}


### PR DESCRIPTION
- Rate limit: 1 request per second per IP
- Returns 429 Too Many Requests when exceeded
- Auto cleanup: removes inactive IPs after 30 minutes
- Background goroutine runs every 10 minutes
- Prevents memory leak from unbounded IP accumulation